### PR TITLE
Hardware timer, New standardized functions

### DIFF
--- a/demo.cpp
+++ b/demo.cpp
@@ -83,7 +83,7 @@ void demo(uint8_t routine){
       for (int d=0;d<PIXEL_MAX;d++){
         fgen_pixel_picker(g_bitmap, DIMC, d);
         FrekvensLoadBuffer(g_bitmap, DIMC);
-        tempmrefresh(8);
+        FrekvensRefreshDisplay();
         delay(STEP_DELAY_2);
       }
 

--- a/demo.cpp
+++ b/demo.cpp
@@ -59,7 +59,7 @@ void demo(uint8_t routine){
       break;
       //end test routine 1
     
-    //test routine 2: pixel chase - sequential
+    //test routine 2: mrefresh, pixel chase - forward
     case 2:
       for (int d=0;d<PIXEL_MAX;d++){
         fgen_pixel_picker(g_bitmap, DIMC, d);
@@ -69,11 +69,11 @@ void demo(uint8_t routine){
       break;
       //end test routine 2
     
-    //test routine 3: pixel chase - reverse
+    //test routine 3: mrefresh2, pixel chase - reverse
     case 3:
       for (int d=PIXEL_MAX;d>0;d--){
         fgen_pixel_picker(g_bitmap, DIMC, d);
-        mrefresh(g_bitmap, DIMC, 8, LATCH_PIN, OE_PIN);
+        mrefresh2(g_bitmap, DIMC, 8);
         delay(STEP_DELAY_2);
       }
       break;

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,6 +1,34 @@
 #include "demo.h"
 
+//NOP instruction
+//inline assembly
+#define NOP __asm__ __volatile__ ("nop\n\t")
+
 uint8_t id = 0;
+
+//DEPRECATED FUNCTION FOR LEGACY DEMO ROUTINE (cluster stepper)
+void refresh(uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols, uint8_t latch, uint8_t enable){
+	if (!(frame&&*frame))
+		return;
+	
+  digitalWrite(enable, HIGH);	//blank display
+
+  SPI.beginTransaction(SPISettings(125000, LSBFIRST, SPI_MODE0));
+	//Last value first
+  //SRORDER: LSBFIRST
+	for(int j=cols;j>0;j--){
+		for(int i=rows;i>0;i--){
+    int received = SPI.transfer(frame[i-1][j-1]);
+		}
+	}
+  SPI.endTransaction();
+
+  digitalWrite(latch, HIGH);	//latch new values
+  NOP;
+  digitalWrite(latch, LOW);
+
+  digitalWrite(enable, LOW);	//enable display
+}
 
 void demo(uint8_t routine){
   if (routine<1 || routine>DEFINED_ROUTINES)

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,5 +1,7 @@
 #include "demo.h"
 
+uint8_t id = 0;
+
 void demo(uint8_t routine){
   if (routine<1 || routine>DEFINED_ROUTINES)
     return;
@@ -53,6 +55,16 @@ void demo(uint8_t routine){
   }
   // END OF DEMO ROUTINES
   //--------------------------------------------------------------------
+}
+
+void demoInterrupt(){
+    fgen_pixel_picker(g_bitmap, DIMC, id);
+    mrefresh(g_bitmap, DIMC, 8, LATCH_PIN, OE_PIN);
+  if (id<255){
+    id++;
+    return;
+  }
+  id=0;
 }
 
 void fgen_cluster_picker(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols, int segment, uint8_t data){

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,10 +1,16 @@
 #include "demo.h"
 
-//NOP instruction
-//inline assembly
-#define NOP __asm__ __volatile__ ("nop\n\t")
-
 uint8_t id = 0;
+
+//Demo routine counter
+int g_routine = FIRST_ROUTINE;
+
+/**
+* DEPRECATED ARRAY
+* Direct frame data.
+* Pixels are represented by bits. The array can be transmitted directly to the LED drivers.
+*/
+uint8_t g_frame[ROWC][COLC];
 
 //DEPRECATED FUNCTION FOR LEGACY DEMO ROUTINE (cluster stepper)
 void refresh(uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols, uint8_t latch, uint8_t enable){
@@ -24,16 +30,19 @@ void refresh(uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols, uint8_t latch, 
   SPI.endTransaction();
 
   digitalWrite(latch, HIGH);	//latch new values
-  NOP;
+  _NOP();
   digitalWrite(latch, LOW);
 
   digitalWrite(enable, LOW);	//enable display
 }
 
 void demo(uint8_t routine){
-  if (routine<1 || routine>DEFINED_ROUTINES)
+  if (g_routine<1 || g_routine>DEFINED_ROUTINES)
     return;
-  
+  Serial.print("Demo routine ");
+  Serial.print(g_routine);
+  Serial.println(" running");
+
   //--------------------------------------------------------------------
   // WRITE DEMO ROUTINES HERE AS CASES:
   switch (routine){
@@ -90,6 +99,12 @@ void demo(uint8_t routine){
     default:
       break;
   }
+
+  //Clear display
+  fgen_pixel_picker(g_bitmap, DIMC, 404);
+  mrefresh2(g_bitmap, DIMC, 8);
+
+  Serial.println("Demo routine finished");
   // END OF DEMO ROUTINES
   //--------------------------------------------------------------------
 }

--- a/demo.cpp
+++ b/demo.cpp
@@ -80,9 +80,10 @@ void demo(uint8_t routine){
     
     //test routine 4: new SPI algorithm, pixel chase - forward
     case 4:
-      for (int d=PIXEL_MAX;d>0;d--){
+      for (int d=0;d<PIXEL_MAX;d++){
         fgen_pixel_picker(g_bitmap, DIMC, d);
-        tempmrefresh(g_bitmap, DIMC, 8);
+        FrekvensLoadBuffer(g_bitmap, DIMC);
+        tempmrefresh(8);
         delay(STEP_DELAY_2);
       }
 

--- a/demo.cpp
+++ b/demo.cpp
@@ -77,6 +77,14 @@ void demo(uint8_t routine){
         delay(STEP_DELAY_2);
       }
       break;
+    
+    //test routine 4: new SPI algorithm, pixel chase - forward
+    case 4:
+      for (int d=PIXEL_MAX;d>0;d--){
+        fgen_pixel_picker(g_bitmap, DIMC, d);
+        tempmrefresh(g_bitmap, DIMC, 8);
+        delay(STEP_DELAY_2);
+      }
 
     default:
       break;
@@ -86,8 +94,8 @@ void demo(uint8_t routine){
 }
 
 void demoInterrupt(){
-    fgen_pixel_picker(g_bitmap, DIMC, id);
-    mrefresh(g_bitmap, DIMC, 8, LATCH_PIN, OE_PIN);
+  fgen_pixel_picker(g_bitmap, DIMC, id);
+  mrefresh(g_bitmap, DIMC, 8, LATCH_PIN, OE_PIN);
   if (id<255){
     id++;
     return;

--- a/demo.h
+++ b/demo.h
@@ -12,7 +12,15 @@
 #include "params.h"
 #include "shift.h"
 
+//-------------------------------------------------
+// DEMO PARAMETERS
+//Define this for interrupt-based demo sequence
+#define DEMO_INTERRUPT
+//The starting point of the normal demo sequence
+#define FIRST_ROUTINE 2
+//Number of defined cases in demo function
 #define DEFINED_ROUTINES 3
+//-------------------------------------------------
 
 #define CLUSTER_DATA  255
 #define CLUSTER_MAX 32
@@ -43,9 +51,14 @@
 * Calling this function produces a predefined image sequence.
 * Number of routines must be set in DEFINED_ROUTINES macro
 *
-* routine:    ID of requested routine.
+* routine:    ID of requested routine. Write 0 to skip.
 */
 void demo(uint8_t routine);
+
+/**
+* Call this from a timer interrupt
+*/
+void demoInterrupt();
 
 /**
 * TEST FUNCTION

--- a/demo.h
+++ b/demo.h
@@ -30,17 +30,14 @@
 #define STEP_DELAY_2 30
 
 // EXTERNAL VARIABLES
-  /**
-  * Direct frame data
-  * Pixels are represented by bits. The array can be transmitted directly to the LED drivers.
-  */
-  extern uint8_t g_frame[ROWC][COLC];
 
   /**
   * Full frame bitmap
   * Defines a byte for each pixel for grayscale data (future use).
   */
   extern uint8_t g_bitmap[DIMC][DIMC];
+
+  extern int g_routine;
 
   //Pin definitions
   extern const int LATCH_PIN;

--- a/demo.h
+++ b/demo.h
@@ -15,11 +15,11 @@
 #define VERBOSE_DEMO
 #undef  VERBOSE_DEMO
 //Define this for interrupt-based demo sequence
-#define DEMO_INTERRUPT
+//#define DEMO_INTERRUPT
 //The starting point of the normal demo sequence
-#define FIRST_ROUTINE 2
+#define FIRST_ROUTINE 3
 //Number of defined cases in demo function
-#define DEFINED_ROUTINES 3
+#define DEFINED_ROUTINES 4
 //-------------------------------------------------
 
 #define CLUSTER_DATA  255

--- a/demo.h
+++ b/demo.h
@@ -4,9 +4,6 @@
 #ifndef _DEMO_H_INCLUDED
 #define _DEMO_H_INCLUDED
 
-#define VERBOSE_DEMO
-#undef  VERBOSE_DEMO
-
 #include <Arduino.h>
 
 #include "params.h"
@@ -14,6 +11,9 @@
 
 //-------------------------------------------------
 // DEMO PARAMETERS
+//Option for serial output
+#define VERBOSE_DEMO
+#undef  VERBOSE_DEMO
 //Define this for interrupt-based demo sequence
 #define DEMO_INTERRUPT
 //The starting point of the normal demo sequence

--- a/frekvens_eval.ino
+++ b/frekvens_eval.ino
@@ -51,6 +51,7 @@ void blank_frame(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols);
 //===========================================
 
 void setup() {
+  //-----------------------------------------------------------
   /*
   * HARDWARE SPECIFIC CODE
   * Arduino Uno timer1 configuration
@@ -69,23 +70,24 @@ void setup() {
   TIMSK1 |= (1<<OCIE1A);  //Enable output compare interrupt
   sei();  //Enable interrupts
   //End timer configuration
+  //-----------------------------------------------------------
 
   Serial.begin(115200);
 
-  if (!attachDisplay(LATCH_PIN, OE_PIN)){
+  if (!FrekvensAttachDisplay(LATCH_PIN, OE_PIN)){
     Serial.println("Display initialization failed!");
     Serial.println("Incorrect pin definitions");
     while(1){}
   }
 
-  disableDisplay();
+  FrekvensDisableDisplay();
 
   SPI.begin();
 
   blank_bitmap(g_bitmap, DIMC);
   blank_frame(g_frame, ROWC, COLC);
 
-  enableDisplayDimming(DISPLAY_DIMNESS);
+  FrekvensEnableDisplayDimming(DISPLAY_DIMNESS);
 }
 
 //===========================================

--- a/frekvens_eval.ino
+++ b/frekvens_eval.ino
@@ -22,31 +22,15 @@
 // GLOBAL VARIABLES
 
   /**
-  * Direct frame data.
-  * Pixels are represented by bits. The array can be transmitted directly to the LED drivers.
-  */
-  uint8_t g_frame[ROWC][COLC];
-
-  /**
   * EXTERNAL VARIABLE
   * Frame bitmap array (from shift.h)
   */
   extern uint8_t g_bitmap[DIMC][DIMC];
 
-  /**
-  * Define semaphores here if needed
-  */
-
-
-  //test routine (demo)
-  int g_routine = FIRST_ROUTINE;
-
 //-------------------------------------------
 // FUNCTION DECLARATIONS
 
-void blank_bitmap(uint8_t (*bitmap)[DIMC], uint8_t dim);
 
-void blank_frame(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols);
 
 //===========================================
 
@@ -84,61 +68,39 @@ void setup() {
 
   SPI.begin();
 
-  blank_bitmap(g_bitmap, DIMC);
-  blank_frame(g_frame, ROWC, COLC);
-
   FrekvensEnableDisplayDimming(DISPLAY_DIMNESS);
 }
 
 //===========================================
 
 void loop() {
-
+  //DEMO ROUTINE
   #ifdef _DEMO_H_INCLUDED
     #ifndef DEMO_INTERRUPT
-    //DEMO ROUTINE
-    Serial.print("Demo routine ");
-    Serial.print(g_routine);
-    Serial.println(" running");
-    demo(g_routine);
-    if (g_routine<DEFINED_ROUTINES)
-      g_routine++;
-    else
-      g_routine=FIRST_ROUTINE;
-    blank_bitmap(g_bitmap, DIMC);
-    blank_frame(g_frame, ROWC, COLC);
-    mrefresh(g_bitmap, DIMC, 8, LATCH_PIN, OE_PIN);
-    Serial.println("Demo routine finished");
-    //END DEMO ROUTINE
+      demo(g_routine);
+      if (g_routine<DEFINED_ROUTINES)
+        g_routine++;
+      else
+        g_routine=FIRST_ROUTINE;
+      return; //Break loop here
     #endif //DEMO_INTERRUPT
   #endif //_DEMO_H_INCLUDED
+  //END DEMO ROUTINE
+
 
 }
 
 //-------------------------------------------
 // FUNCTION DEFINITIONS
 
-void blank_bitmap(uint8_t (*bitmap)[DIMC], uint8_t dim){
-  for(int i=0;i<dim;i++){
-    for(int j=0;j<dim;j++){
-      bitmap[i][j]=0;
-    }
-  }
-}
 
-void blank_frame(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols){
-  for(int i=0;i<rows;i++){
-    for(int j=0;j<cols;j++){
-      frame[i][j]=0;
-    }
-  }
-}
 
-//===========================================
+//-------------------------------------------
 // INTERRUPT SERVICE ROUTINES
 
 ISR(TIMER1_COMPA_vect){
   #if defined(_DEMO_H_INCLUDED) && defined(DEMO_INTERRUPT)
   demoInterrupt();
+  return;
   #endif
 }

--- a/frekvens_eval.ino
+++ b/frekvens_eval.ino
@@ -55,7 +55,9 @@ void setup() {
   * HARDWARE SPECIFIC CODE
   * Arduino Uno timer1 configuration
   * 
-  * Current frequency: 6410 Hz
+  * Current frequency: 400 Hz
+  * frequency | CSx2-1-0  | OCR
+  * 400 Hz    | 0-1-0     | 2499
   */
   cli();  //Clear interrupts
   TCCR1A = 0; //Timer-Counter Control Register 1A
@@ -63,7 +65,7 @@ void setup() {
   TCNT1 = 0;  //initialize counter value to 0
   TCCR1B |= (1<<WGM12);
   TCCR1B |= (0<<CS12) | (1<<CS11) | (0<<CS10);
-  OCR1A = 155; //Output compare register value
+  OCR1A = 2499; //Output compare register value
   TIMSK1 |= (1<<OCIE1A);  //Enable output compare interrupt
   sei();  //Enable interrupts
   //End timer configuration

--- a/frekvens_eval.ino
+++ b/frekvens_eval.ino
@@ -54,6 +54,21 @@ void blank_frame(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols);
 //===========================================
 
 void setup() {
+  /*
+  * HARDWARE SPECIFIC CODE
+  * Arduino Uno timer1 configuration
+  */
+  cli();  //Clear interrupts
+  TCCR1A = 0; //Timer-Counter Control Register 1A
+  TCCR1B = 0;
+  TCNT1 = 0;  //initialize counter value to 0
+  TCCR1B |= (1<<WGM12);
+  TCCR1B |= (1<<CS12) | (1<<CS10);
+  OCR1A = 7812; //Output compare register for:    1 Hz
+  TIMSK1 |= (1<<OCIE1A);  //Enable output compare interrupt
+  sei();  //Enable interrupts
+  //End timer configuration
+
   Serial.begin(115200);
 
   if (!attachDisplay(LATCH_PIN, OE_PIN)){
@@ -112,4 +127,11 @@ void blank_frame(uint8_t (*frame)[COLC], uint8_t rows, uint8_t cols){
       frame[i][j]=0;
     }
   }
+}
+
+//===========================================
+// INTERRUPT ROUTINES
+
+ISR(TIMER1_COMPA_vect){
+  //do something in the interrupt service routine
 }

--- a/shift.cpp
+++ b/shift.cpp
@@ -148,15 +148,15 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
     uint8_t cnt = 0;
     for (int j=0;j<COLB;j++){
       for (int k=0;k<8;k++){
-        i_frame_buffer[i][j] >>= 1;
+        i_frame_buffer[i][j] <<= 1;
         if ((bitmap[i][cnt] & bitmask[mask]))
-          i_frame_buffer[i][j] |= 128;
+          i_frame_buffer[i][j] |= 1;
         cnt++;
       }
     }
   }
   //Transmit frame through SPI
-  SPI.beginTransaction(SPISettings(FREKVENS_SRSPEED, LSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(SPISettings(FREKVENS_SRSPEED, MSBFIRST, SPI_MODE0));
 	//Last value first
   //SRORDER: LSBFIRST
 	for(int j=0;j<COLB;j++){
@@ -183,15 +183,15 @@ void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
     uint8_t cnt = 0;
     for (int j=0;j<COLB;j++){
       for (int k=0;k<8;k++){
-        i_frame_buffer[i][j] >>= 1;
+        i_frame_buffer[i][j] <<= 1;
         if ((bitmap[i][cnt] & bitmask[mask]))
-          i_frame_buffer[i][j] |= 128;
+          i_frame_buffer[i][j] |= 1;
         cnt++;
       }
     }
   }
   //Transmit frame through SPI
-  SPI.beginTransaction(SPISettings(FREKVENS_SRSPEED, LSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(SPISettings(FREKVENS_SRSPEED, MSBFIRST, SPI_MODE0));
 	//Last value first
   //SRORDER: LSBFIRST
 	for(int j=0;j<COLB;j++){

--- a/shift.cpp
+++ b/shift.cpp
@@ -171,11 +171,6 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
   digitalWrite(latch, LOW);
 }
 
-void tempmrefresh(uint8_t mask){
-  i_map(mask);
-  i_refresh();
-}
-
 void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
   if (!(bitmap&&*bitmap))
 		return;

--- a/shift.cpp
+++ b/shift.cpp
@@ -14,6 +14,9 @@
 
 uint8_t g_bitmap[DIMC][DIMC];
 
+bool flag_bitmap_available = true;
+bool flag_frame_available = true;
+
 uint8_t bitmap_buffer[DIMC][DIMC];
 uint8_t frame_buffer[DIMC][COLB];
 
@@ -74,12 +77,16 @@ bool attachDisplay(int latch_pin, int enable_pin){
 }
 
 void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension){
-  if (!(bitmap&&*bitmap))
+  if (!(bitmap&&*bitmap) && dimension!=DIMC)
 		return;
-  if (dimension!=DIMC)
+  //if (dimension!=DIMC)
+    //return;
+  if (!flag_bitmap_available)
     return;
 
+  flag_bitmap_available = false;
   memcpy(bitmap_buffer, bitmap, DIMC*DIMC);
+  flag_bitmap_available = true;
 }
 
 //DEPRECATED FUNCTION!

--- a/shift.cpp
+++ b/shift.cpp
@@ -124,6 +124,27 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
   digitalWrite(latch, LOW);
 }
 
+void tempmrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
+  if (!(bitmap&&*bitmap))
+		return;
+  if (dimension!=DIMC)
+    return;
+
+  //Compile a frame from the bitmap
+  for (int i=0;i<DIMC;i++){
+    uint8_t cnt = 0;
+    for (int j=0;j<COLB;j++){
+      for (int k=0;k<8;k++){
+        frame_buffer[i][j] <<= 1;
+        if ((bitmap[i][cnt] & bitmask[mask]))
+          frame_buffer[i][j] |= 1;
+        cnt++;
+      }
+    }
+  }
+  i_refresh();
+}
+
 void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
   if (!(bitmap&&*bitmap))
 		return;

--- a/shift.cpp
+++ b/shift.cpp
@@ -89,49 +89,6 @@ void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension){
   flag_bitmap_available = true;
 }
 
-//DEPRECATED FUNCTION!
-void refresh(uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols, uint8_t latch, uint8_t enable){
-	if (!(frame&&*frame))
-		return;
-	
-  digitalWrite(enable, HIGH);	//blank display
-
-  SPI.beginTransaction(SPISettings(SRSPEED, SRORDER, SRMODE));
-	//Last value first
-  //SRORDER: LSBFIRST
-	for(int j=cols;j>0;j--){
-		for(int i=rows;i>0;i--){
-    int received = SPI.transfer(frame[i-1][j-1]);
-		}
-	}
-  SPI.endTransaction();
-
-  digitalWrite(latch, HIGH);	//latch new values
-  NOP;
-  digitalWrite(latch, LOW);
-
-  digitalWrite(enable, LOW);	//enable display
-}
-
-//DEPRECATED FUNCTION!
-bool map(uint8_t (*bitmap)[DIMC], uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols){
-  if (!(bitmap&&*bitmap) || !(frame&&*frame))
-    return false;
-
-  for (int i=0;i<rows;i++){
-    uint8_t cnt = 0;
-    for (int j=0;j<cols;j++){
-      for (int k=0;k<8;k++){
-        frame[i][j] <<= 1;
-        if (bitmap[i][cnt])
-          frame[i][j] |= 1;
-        cnt++;
-      }
-    }
-  }
-  return true;
-}
-
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable){
 	if (!(bitmap&&*bitmap))
 		return;
@@ -202,40 +159,7 @@ void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
   digitalWrite(displayData.latch, LOW);
 }
 
-//DEPRECATED FUNCTION!
-void gmrefresh(uint8_t mask, uint8_t latch, uint8_t enable){
-  if (!g_bitmap)
-		return;
-	
-  //Compile a frame from the bitmap
-  uint8_t frame_buffer[DIMC][COLB];
-  for (int i=0;i<DIMC;i++){
-    uint8_t cnt = 0;
-    for (int j=0;j<COLB;j++){
-      for (int k=0;k<8;k++){
-        frame_buffer[i][j] >>= 1;
-        if ((g_bitmap[i][cnt] & bitmask[mask]))
-          frame_buffer[i][j] |= 128;
-        cnt++;
-      }
-    }
-  }
-  //Transmit frame through SPI
-  SPI.beginTransaction(SPISettings(SRSPEED, SRORDER, SRMODE));
-	//Last value first
-  //SRORDER: LSBFIRST
-	for(int j=COLB-1;j>=0;j--){
-		for(int i=DIMC-1;i>=0;i--){
-    int received = SPI.transfer(frame_buffer[i][j]);
-		}
-	}
-  SPI.endTransaction();
-
-  digitalWrite(latch, HIGH);	//latch new values
-  NOP;
-  digitalWrite(latch, LOW);
-}
-
+//Deprecated function!
 static inline uint8_t mapb(uint8_t* address, uint8_t buffer){
     buffer <<= 1;
     if (*address)

--- a/shift.cpp
+++ b/shift.cpp
@@ -62,7 +62,7 @@ static inline bool i_refresh(){
   return true;
 }
 
-bool attachDisplay(int latch_pin, int enable_pin){
+bool FrekvensAttachDisplay(int latch_pin, int enable_pin){
   if (latch_pin==enable_pin)
     return false;
   displayData.latch = latch_pin;
@@ -76,7 +76,7 @@ bool attachDisplay(int latch_pin, int enable_pin){
   return true;
 }
 
-void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension){
+void FrekvensLoadBuffer(uint8_t (*bitmap)[DIMC], uint8_t dimension){
   if (!(bitmap&&*bitmap) && dimension!=DIMC)
 		return;
   //if (dimension!=DIMC)
@@ -124,24 +124,8 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
   digitalWrite(latch, LOW);
 }
 
-void tempmrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask){
-  if (!(bitmap&&*bitmap))
-		return;
-  if (dimension!=DIMC)
-    return;
-
-  //Compile a frame from the bitmap
-  for (int i=0;i<DIMC;i++){
-    uint8_t cnt = 0;
-    for (int j=0;j<COLB;j++){
-      for (int k=0;k<8;k++){
-        frame_buffer[i][j] <<= 1;
-        if ((bitmap[i][cnt] & bitmask[mask]))
-          frame_buffer[i][j] |= 1;
-        cnt++;
-      }
-    }
-  }
+void tempmrefresh(uint8_t mask){
+  i_map(mask);
   i_refresh();
 }
 
@@ -189,7 +173,7 @@ static inline uint8_t mapb(uint8_t* address, uint8_t buffer){
   return buffer;
 }
 
-void enableDisplayDimming(uint8_t dimness){
+void FrekvensEnableDisplayDimming(uint8_t dimness){
   if (dimness>0 && dimness<255){
     analogWrite(displayData.enable, dimness);
     return;
@@ -197,10 +181,10 @@ void enableDisplayDimming(uint8_t dimness){
   digitalWrite(displayData.enable, LOW);
 }
 
-void enableDisplay(){
+void FrekvensEnableDisplay(){
   digitalWrite(displayData.enable, LOW);
 }
 
-void disableDisplay(){
+void FrekvensDisableDisplay(){
   digitalWrite(displayData.enable, HIGH);
 }

--- a/shift.cpp
+++ b/shift.cpp
@@ -43,7 +43,7 @@ static inline bool i_map(uint8_t mask){
 }
 
 //Local version of refresh function
-static inline bool i_refresh(uint8_t mask){
+static inline bool i_refresh(){
   //Transmit the frame through SPI
   SPI.beginTransaction(SPISettings(SRSPEED, MSBFIRST, SRMODE));
 	for(int j=0;j<COLB;j++){
@@ -71,6 +71,15 @@ bool attachDisplay(int latch_pin, int enable_pin){
   digitalWrite(latch_pin, LOW);
   digitalWrite(enable_pin, LOW);  //Enable display
   return true;
+}
+
+void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension){
+  if (!(bitmap&&*bitmap))
+		return;
+  if (dimension!=DIMC)
+    return;
+
+  memcpy(bitmap_buffer, bitmap, DIMC*DIMC);
 }
 
 //DEPRECATED FUNCTION!

--- a/shift.cpp
+++ b/shift.cpp
@@ -16,15 +16,9 @@ uint8_t g_bitmap[DIMC][DIMC];
 
 /**
 * GLOBAL FLAG
-* Bitmap buffer access control flag
+* Activity indicator for synchronising display related operations
 */
-bool flag_bitmap_available = true;
-
-/**
-* GLOBAL FLAG
-* Frame buffer access control flag
-*/
-bool flag_frame_available = true;
+bool flag_frekvens_activity = false;
 
 /**
 * GLOBAL VARIABLE
@@ -63,10 +57,6 @@ bool FrekvensAttachDisplay(int latch_pin, int enable_pin){
 void FrekvensLoadBuffer(uint8_t (*bitmap)[DIMC], uint8_t dimension){
   if (!(bitmap&&*bitmap) && dimension!=DIMC)
 		return;
-  //if (dimension!=DIMC)
-    //return;
-  if (!flag_bitmap_available)
-    return;
 
   memcpy(i_bitmap_buffer, bitmap, DIMC*DIMC);
 }

--- a/shift.h
+++ b/shift.h
@@ -1,12 +1,13 @@
 // frekvens_driver.h
 // Display driver for FREKVENS LED array
 
-#include <Arduino.h>
-#include <SPI.h>
+#ifndef FREKVENS_DRIVER_H_INCLUDED
+#define FREKVENS_DRIVER_H_INCLUDED
 
-//NOP instruction
-//inline assembly
-#define NOP __asm__ __volatile__ ("nop\n\t")
+#include <Arduino.h>
+#ifndef _SPI_H_INCLUDED
+#include <SPI.h>
+#endif
 
 //Common dimension (rows)
 //Display is (DIMC) pixels tall
@@ -14,11 +15,6 @@
 //Column count for the frame buffer
 //Display is (COLB x 8) pixels wide
 #define COLB 2
-
-//SPISettings parameters
-#define SRSPEED 125000      //speedMaximum
-#define SRORDER LSBFIRST    //dataOrder
-#define SRMODE SPI_MODE0    //dataMode
 
 /**
 * GLOBAL VARIABLE
@@ -68,6 +64,19 @@ bool map(uint8_t (*bitmap)[DIMC], uint8_t (*frame)[COLB], uint8_t rows, uint8_t 
 */
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable);
 
+/**
+* New version of mrefresh() using internal sources for display parameters.
+* Compiles the frame from the bitmap and transmits it to the LED drivers via SPI.
+* "map-and-refresh"
+*
+* *bitmap:    Byte array that contains the image.
+* dimension:  Dimension of passed array (must be square!).
+* mask:       Bitmask for grayscale processing. Write 8 to prevent masking.
+* latch:      Latch pin number.
+* enable:     Output Enable pin number.
+*/
+void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask);
+
 /*
 * //DEPRECATED FUNCTION!
 * Compiles the frame from the global bitmap and transmits it to the LED drivers via SPI
@@ -95,3 +104,5 @@ void enableDisplay(uint8_t dimness);
 * Disable the display via the Output Enable pin
 */
 void disableDisplay();
+
+#endif //FREKVENS_DRIVER_H_INCLUDED

--- a/shift.h
+++ b/shift.h
@@ -20,8 +20,7 @@
 extern uint8_t g_bitmap[DIMC][DIMC];
 extern uint8_t frekvens_bitmask_index;
 
-extern bool flag_bitmap_available;
-extern bool flag_frame_available;
+extern bool flag_frekvens_activity;
 
 /**
 * Defines the physical connections to the display driver ICs

--- a/shift.h
+++ b/shift.h
@@ -35,7 +35,7 @@ extern uint8_t g_bitmap[DIMC][DIMC];
 * latch_pin:    Latch pin number.
 * enable_pin:   Output Enable pin number.
 */
-bool attachDisplay(int latch_pin, int enable_pin);
+bool FrekvensAttachDisplay(int latch_pin, int enable_pin);
 
 /**
 * WIP (part of grayscale image processor)
@@ -44,7 +44,7 @@ bool attachDisplay(int latch_pin, int enable_pin);
 * *bitmap:    Byte array that contains the image.
 * dimension:  Dimension of bitmap (square matrix).
 */
-void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension);
+void FrekvensLoadBuffer(uint8_t (*bitmap)[DIMC], uint8_t dimension);
 
 /**
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI
@@ -57,7 +57,7 @@ void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension);
 */
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable);
 
-void tempmrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask);
+void tempmrefresh(uint8_t mask);
 
 /**
 * New version of mrefresh() using internal sources for display parameters.
@@ -83,16 +83,16 @@ static inline uint8_t mapb(uint8_t* address, uint8_t buffer);
 * 
 * dimness:      Dimness value (1 - 254). Write 0 or 'false' to disable PWM.
 */
-void enableDisplayDimming(uint8_t dimness);
+void FrekvensEnableDisplayDimming(uint8_t dimness);
 
 /**
 * Enable the display
 */
-void enableDisplay();
+void FrekvensEnableDisplay();
 
 /**
 * Disable the display
 */
-void disableDisplay();
+void FrekvensDisableDisplay();
 
 #endif //FREKVENS_DRIVER_H_INCLUDED

--- a/shift.h
+++ b/shift.h
@@ -20,8 +20,8 @@
 extern uint8_t g_bitmap[DIMC][DIMC];
 extern uint8_t frekvens_bitmask_index;
 
-//extern bool flag_bitmap_available;
-//extern bool flag_frame_available;
+extern bool flag_bitmap_available;
+extern bool flag_frame_available;
 
 /**
 * Defines the physical connections to the display driver ICs
@@ -32,13 +32,21 @@ extern uint8_t frekvens_bitmask_index;
 bool FrekvensAttachDisplay(int latch_pin, int enable_pin);
 
 /**
-* WIP (part of grayscale image processor)
-* Load a bitmap into the local buffer
+* Load a complete bitmap into the display buffer
 * 
 * *bitmap:    Byte array that contains the image.
 * dimension:  Dimension of bitmap (square matrix).
 */
 void FrekvensLoadBuffer(uint8_t (*bitmap)[DIMC], uint8_t dimension);
+
+/**
+* Load data to the specified pixel of the display buffer.
+* 
+* data:   The data to be loaded.
+* row:    Bitmap X coordinate.
+* col:    Bitmap Y coordinate.
+*/
+void FrekvensLoadPixel(uint8_t data, uint8_t row, uint8_t col);
 
 /**
 * Refresh the display with the buffered bitmap.
@@ -49,11 +57,11 @@ void FrekvensRefreshDisplay();
 /**
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI
 *
-* *bitmap:  Byte array that contains the image.
-* dimension:      Dimension of bitmap (square matrix).
-* mask:     Bitmask for grayscale processing. Write 8 to prevent masking.
-* latch:    Latch pin number.
-* enable:   Output Enable pin number.
+* *bitmap:    Byte array that contains the image.
+* dimension:  Dimension of bitmap (square matrix).
+* mask:       Bitmask for grayscale processing. Write 8 to prevent masking.
+* latch:      Latch pin number.
+* enable:     Output Enable pin number.
 */
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable);
 
@@ -65,21 +73,13 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
 * *bitmap:    Byte array that contains the image.
 * dimension:  Dimension of passed array (must be square!).
 * mask:       Bitmask for grayscale processing. Write 8 to prevent masking.
-* latch:      Latch pin number.
-* enable:     Output Enable pin number.
 */
 void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask);
-
-/*
-* //DEPRECATED FUNCTION!
-* Compiles a single byte from eitght consecutive values by address
-*/
-static inline uint8_t mapb(uint8_t* address, uint8_t buffer);
 
 /**
 * Enable the display with global PWM dimming via the Output Enable pin.
 * 
-* dimness:      Dimness value (1 - 254). Write 0 or 'false' to disable PWM.
+* dimness:    Dimness value (1 - 254). A value of '0' '255' or 'false' disables PWM dimming.
 */
 void FrekvensEnableDisplayDimming(uint8_t dimness);
 

--- a/shift.h
+++ b/shift.h
@@ -23,6 +23,13 @@
 extern uint8_t g_bitmap[DIMC][DIMC];
 
 /**
+* GLOBAL VARIABLE
+* Buffer access control flags
+*/
+//extern bool flag_bitmap_available;
+//extern bool flag_frame_available;
+
+/**
 * Defines the physical connections to the display driver ICs
 *
 * latch_pin:    Latch pin number.

--- a/shift.h
+++ b/shift.h
@@ -57,6 +57,8 @@ void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension);
 */
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable);
 
+void tempmrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask);
+
 /**
 * New version of mrefresh() using internal sources for display parameters.
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI.

--- a/shift.h
+++ b/shift.h
@@ -9,10 +9,10 @@
 #include <SPI.h>
 #endif
 
-//Common dimension (rows)
-//Display is (DIMC) pixels tall
+//Common dimension of display related arrays (rows and columns)
+//Display is square with (DIMC) pixels on all sides
 #define DIMC 16
-//Column count for the frame buffer
+//Column count of the frame buffer array
 //Display is (COLB x 8) pixels wide
 #define COLB 2
 
@@ -46,29 +46,6 @@ bool attachDisplay(int latch_pin, int enable_pin);
 */
 void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension);
 
-/*
-* //DEPRECATED FUNCTION!
-* Transmits the frame to the LED drivers via SPI
-*
-* frame:    byte array, 16x2
-* rows:     array row count
-* cols:     array column count
-* latch:    Latch pin number
-* enable:   Output Enable pin number
-*/
-void refresh(uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols, uint8_t latch, uint8_t enable);
-
-/*
-* //DEPRECATED FUNCTION!
-* Converts a bitmap into a direct frame for transmission
-*
-* bitmap:   byte array, 16x16
-* frame:    byte array, 16x2
-* rows:     array row count (bitmap and frame)
-* cols:     array column count (frame)
-*/
-bool map(uint8_t (*bitmap)[DIMC], uint8_t (*frame)[COLB], uint8_t rows, uint8_t cols);
-
 /**
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI
 *
@@ -92,16 +69,6 @@ void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t 
 * enable:     Output Enable pin number.
 */
 void mrefresh2(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask);
-
-/*
-* //DEPRECATED FUNCTION!
-* Compiles the frame from the global bitmap and transmits it to the LED drivers via SPI
-*
-* mask:     Bitmask for grayscale processing. Write 8 to prevent masking.
-* latch:    Latch pin number.
-* enable:   Output Enable pin number.
-*/
-void gmrefresh(uint8_t mask, uint8_t latch, uint8_t enable);
 
 /*
 * //DEPRECATED FUNCTION!

--- a/shift.h
+++ b/shift.h
@@ -30,6 +30,15 @@ extern uint8_t g_bitmap[DIMC][DIMC];
 */
 bool attachDisplay(int latch_pin, int enable_pin);
 
+/**
+* WIP (part of grayscale image processor)
+* Load a new bitmap into the local buffer
+* 
+* *bitmap:    Byte array that contains the image.
+* dimension:  Dimension of bitmap (square matrix).
+*/
+void bufferLoad(uint8_t (*bitmap)[DIMC], uint8_t dimension);
+
 /*
 * //DEPRECATED FUNCTION!
 * Transmits the frame to the LED drivers via SPI

--- a/shift.h
+++ b/shift.h
@@ -16,16 +16,10 @@
 //Display is (COLB x 8) pixels wide
 #define COLB 2
 
-/**
-* GLOBAL VARIABLE
-* Frame bitmap array
-*/
-extern uint8_t g_bitmap[DIMC][DIMC];
 
-/**
-* GLOBAL VARIABLE
-* Buffer access control flags
-*/
+extern uint8_t g_bitmap[DIMC][DIMC];
+extern uint8_t frekvens_bitmask_index;
+
 //extern bool flag_bitmap_available;
 //extern bool flag_frame_available;
 
@@ -39,12 +33,18 @@ bool FrekvensAttachDisplay(int latch_pin, int enable_pin);
 
 /**
 * WIP (part of grayscale image processor)
-* Load a new bitmap into the local buffer
+* Load a bitmap into the local buffer
 * 
 * *bitmap:    Byte array that contains the image.
 * dimension:  Dimension of bitmap (square matrix).
 */
 void FrekvensLoadBuffer(uint8_t (*bitmap)[DIMC], uint8_t dimension);
+
+/**
+* Refresh the display with the buffered bitmap.
+* Masking must be set via global variable 'frekvens_bitmask_index'
+*/
+void FrekvensRefreshDisplay();
 
 /**
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI

--- a/shift.h
+++ b/shift.h
@@ -57,8 +57,6 @@ void FrekvensRefreshDisplay();
 */
 void mrefresh(uint8_t (*bitmap)[DIMC], uint8_t dimension, uint8_t mask, uint8_t latch, uint8_t enable);
 
-void tempmrefresh(uint8_t mask);
-
 /**
 * New version of mrefresh() using internal sources for display parameters.
 * Compiles the frame from the bitmap and transmits it to the LED drivers via SPI.


### PR DESCRIPTION
Add hardware timer interrupt functionality, which makes asynchronous display refreshing possible.

Applied standardized naming scheme to latest driver functions.
All relevant driver functions now use PascalCase and start with "Frekvens" tag for easy recognition.
New display related functions:
- FrekvensLoadBuffer
- FrekvensLoadPixel
- FrekvensRefreshDisplay

Had a round of code cleanup, removed deprecated and unused functions.
Some legacy functions were moved to demo file for compatibility.